### PR TITLE
スレッドの一覧と詳細ページ追加

### DIFF
--- a/bbsample/app/controllers/HomeController.scala
+++ b/bbsample/app/controllers/HomeController.scala
@@ -3,6 +3,7 @@ package controllers
 import javax.inject._
 import play.api._
 import play.api.mvc._
+import models._
 
 /**
  * This controller creates an `Action` to handle HTTP requests to the
@@ -19,6 +20,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
    * a path of `/`.
    */
   def index() = Action { implicit request: Request[AnyContent] =>
-    Ok(views.html.index())
+    val topics = Seq(Topic(1, "タイトル", "ないようないよう"))
+    Ok(views.html.index(topics))
   }
 }

--- a/bbsample/app/controllers/HomeController.scala
+++ b/bbsample/app/controllers/HomeController.scala
@@ -20,7 +20,8 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
    * a path of `/`.
    */
   def index() = Action { implicit request: Request[AnyContent] =>
-    val topics = Seq(Topic(1, "タイトル", "ないようないよう"))
+    val topics = Seq(
+      Topic(TopicId(1), "タイトル", "ないようないよう"))
     Ok(views.html.index(topics))
   }
 }

--- a/bbsample/app/controllers/TopicsController.scala
+++ b/bbsample/app/controllers/TopicsController.scala
@@ -1,0 +1,16 @@
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.mvc._
+import models._
+
+@Singleton
+class TopicsController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+
+  def show(id: Long) = Action { implicit request: Request[AnyContent] =>
+    val topic = Topic(1, "タイトル", "ないようないよう")
+    val comments = Seq(Comment(1, "コメント1"), Comment(2, "コメント2"))
+    Ok(views.html.Topic.show(topic, comments))
+  }
+}

--- a/bbsample/app/controllers/TopicsController.scala
+++ b/bbsample/app/controllers/TopicsController.scala
@@ -9,8 +9,11 @@ import models._
 class TopicsController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
 
   def show(id: Long) = Action { implicit request: Request[AnyContent] =>
-    val topic = Topic(1, "タイトル", "ないようないよう")
-    val comments = Seq(Comment(1, "コメント1"), Comment(2, "コメント2"))
+    val topic = Topic(TopicId(1), "タイトル", "ないようないよう")
+    val comments = Seq(
+      Comment(CommentId(1), "コメント1"),
+      Comment(CommentId(2), "コメント2")
+    )
     Ok(views.html.Topic.show(topic, comments))
   }
 }

--- a/bbsample/app/models/comment.scala
+++ b/bbsample/app/models/comment.scala
@@ -1,6 +1,8 @@
 package models
 
 case class Comment(
-  id: Long,
+  id: CommentId,
   body: String
 )
+
+case class CommentId(value: Int)

--- a/bbsample/app/models/comment.scala
+++ b/bbsample/app/models/comment.scala
@@ -1,0 +1,6 @@
+package models
+
+case class Comment(
+  id: Long,
+  body: String
+)

--- a/bbsample/app/models/topic.scala
+++ b/bbsample/app/models/topic.scala
@@ -1,0 +1,7 @@
+package models
+
+case class Topic(
+  id: Long,
+  title: String,
+  body: String
+)

--- a/bbsample/app/models/topic.scala
+++ b/bbsample/app/models/topic.scala
@@ -1,7 +1,9 @@
 package models
 
 case class Topic(
-  id: Long,
+  id: TopicId,
   title: String,
   body: String
 )
+
+case class TopicId(value: Int)

--- a/bbsample/app/views/Topic/show.scala.html
+++ b/bbsample/app/views/Topic/show.scala.html
@@ -1,0 +1,11 @@
+@(topic: Topic, comments: Seq[Comment])
+
+@main("Welcome to Play") {
+  <h1>@topic.title</h1>
+
+  <ul>
+    @for(comment <- comments) {
+      <li>@comment.body</li>
+    }
+  </ul>
+}

--- a/bbsample/app/views/index.scala.html
+++ b/bbsample/app/views/index.scala.html
@@ -1,5 +1,11 @@
-@()
+@(topics: Seq[Topic])
 
 @main("Welcome to Play") {
-  <h1>Welcome to Play!</h1>
+  <h1>掲示板</h1>
+
+  <ul>
+    @for(topic <- topics) {
+      <li>@topic.title</li>
+    }
+  </ul>
 }

--- a/bbsample/conf/routes
+++ b/bbsample/conf/routes
@@ -5,6 +5,7 @@
 
 # An example controller showing a sample home page
 GET     /                           controllers.HomeController.index
+GET     /topics/:id                 controllers.TopicsController.show(id: Long)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
スレッドの一覧ページと詳細ページをつくりました。

スレッド詳細ページ
![image](https://user-images.githubusercontent.com/7833726/29927449-6115a5ac-8ea1-11e7-82fe-500625ec9bd8.png)


# Topic設計
スレッド・トピックを表すモデル

|----|----|----|
| id | | |
| title | | トピックタイトル |
| body | | トピック内容 |

# Comment設計

スレッド・トピックへのコメントを表すモデル

|----|----|----|----|
| id | | |
| body | | コメント内容|